### PR TITLE
Workaround for crashes on Android 7

### DIFF
--- a/app/src/main/java/com/hippoandfriends/helpdiabetes/ActivityGroup/ActivityGroupMeal.java
+++ b/app/src/main/java/com/hippoandfriends/helpdiabetes/ActivityGroup/ActivityGroupMeal.java
@@ -124,11 +124,7 @@ public class ActivityGroupMeal extends ActivityGroup {
 
 	// The foodData will always be in history place 0
 	public ShowLoadingFoodData getFoodData() {
-		try {
-			return (ShowLoadingFoodData) history.get(0).getContext();
-		} catch (Exception e) {
-			return null;
-		}
+		return ShowLoadingFoodData.INSTANCE;
 	}
 
 	// The showFoodList will always be in history place 1
@@ -137,11 +133,7 @@ public class ActivityGroupMeal extends ActivityGroup {
 	// This means that history only will have 1 object in its list and that is
 	// on position 0 so position 1 is empty
 	public ShowFoodList getShowFoodList() {
-		try {
-			return (ShowFoodList) history.get(1).getContext();
-		} catch (Exception e) {
-			return null;
-		}
+		return ShowFoodList.INSTANCE;
 	}
 
 	@Override
@@ -247,30 +239,11 @@ public class ActivityGroupMeal extends ActivityGroup {
 
 	// show update food
 	public ShowUpdateFood getShowUpdateFood() {
-		try {
-			View v = history.get(history.size() - 2);
-			return (ShowUpdateFood) v.getContext();
-		} catch (Exception e) {
-			return null;
-		}
+		return ShowUpdateFood.INSTANCE;
 	}
 
 	public ShowSelectedFood getShowSelectedFood() {
-		try {
-			View v = history.get(history.size() - 2);
-			return (ShowSelectedFood) v.getContext();
-		} catch (Exception e) {
-
-			try {
-				// this will be returnd when we delete a template and we refresh
-				// the data
-				View o = history.get(history.size() - 1);
-				return (ShowSelectedFood) o.getContext();
-			} catch (Exception l) {
-				return null;
-			}
-		}
-
+		return ShowSelectedFood.INSTANCE;
 	}
 
 	public void goToSeletedFood() {

--- a/app/src/main/java/com/hippoandfriends/helpdiabetes/ActivityGroup/ActivityGroupSettings.java
+++ b/app/src/main/java/com/hippoandfriends/helpdiabetes/ActivityGroup/ActivityGroupSettings.java
@@ -128,20 +128,12 @@ public class ActivityGroupSettings extends ActivityGroup {
 
 	// The exercise types view will alaways be in history place 1 if it exists
 	public ShowExerciseTypes getExerciseTypes() {
-		try {
-			return (ShowExerciseTypes) history.get(1).getContext();
-		} catch (Exception e) {
-			return null;
-		}
+		return ShowExerciseTypes.INSTANCE;
 	}
 
 	// The medicine types view will alaways be in history place 1 if it exists
 	public ShowMedicineTypes getMedicineTypes() {
-		try {
-			return (ShowMedicineTypes) history.get(1).getContext();
-		} catch (Exception e) {
-			return null;
-		}
+		return ShowMedicineTypes.INSTANCE;
 	}
 
 	// Make for every class a refresh method

--- a/app/src/main/java/com/hippoandfriends/helpdiabetes/ActivityGroup/ActivityGroupTracking.java
+++ b/app/src/main/java/com/hippoandfriends/helpdiabetes/ActivityGroup/ActivityGroupTracking.java
@@ -127,11 +127,7 @@ public class ActivityGroupTracking extends ActivityGroup {
 	}
 	
 	public ShowLoadingTrackingData getTrackingData() {
-		try {
-			return (ShowLoadingTrackingData) history.get(0).getContext();
-		} catch (Exception e) {
-			return null;
-		}
+		return ShowLoadingTrackingData.INSTANCE;
 	}
 
 	// this method will kill the application

--- a/app/src/main/java/com/hippoandfriends/helpdiabetes/Show/Exercise/ShowExerciseTypes.java
+++ b/app/src/main/java/com/hippoandfriends/helpdiabetes/Show/Exercise/ShowExerciseTypes.java
@@ -29,6 +29,8 @@ public class ShowExerciseTypes extends ListActivity {
 	private List<DBExerciseType> listExerciseTypes;
 	private Button btAdd, btBack;
 
+	public static ShowExerciseTypes INSTANCE;
+
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
@@ -55,7 +57,8 @@ public class ShowExerciseTypes extends ListActivity {
 				ActivityGroupSettings.group.back();
 			}
 		});
-		
+
+		INSTANCE = this;
 	}
 
 	//refresh the name of a object

--- a/app/src/main/java/com/hippoandfriends/helpdiabetes/Show/Food/ShowFoodList.java
+++ b/app/src/main/java/com/hippoandfriends/helpdiabetes/Show/Food/ShowFoodList.java
@@ -66,6 +66,8 @@ public class ShowFoodList extends ListActivity {
 	// this animation is used to let the button flash when we have selections
 	private Animation animation;
 
+	public static ShowFoodList INSTANCE;
+
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
@@ -153,6 +155,8 @@ public class ShowFoodList extends ListActivity {
 				onClickSearch();
 			}
 		});
+
+		INSTANCE = this;
 	}
 
 	// This method will show the gray or the highlighted search button

--- a/app/src/main/java/com/hippoandfriends/helpdiabetes/Show/Food/ShowLoadingFoodData.java
+++ b/app/src/main/java/com/hippoandfriends/helpdiabetes/Show/Food/ShowLoadingFoodData.java
@@ -76,6 +76,8 @@ public class ShowLoadingFoodData extends Activity {
 	public String dbTopOneCommonFoodUnit;
 	public String dbTopTwoCommonFoodUnit;
 
+	public static ShowLoadingFoodData INSTANCE;
+
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
@@ -86,6 +88,7 @@ public class ShowLoadingFoodData extends Activity {
 		setContentView(contentView);
 
 		context = this;
+		INSTANCE = this;
 	}
 
 	@Override

--- a/app/src/main/java/com/hippoandfriends/helpdiabetes/Show/Food/ShowSelectedFood.java
+++ b/app/src/main/java/com/hippoandfriends/helpdiabetes/Show/Food/ShowSelectedFood.java
@@ -78,6 +78,8 @@ public class ShowSelectedFood extends ListActivity {
 	// to write to the database when listview expand or collaps
 	private DbAdapter expandOrNotDBAdapater;
 
+	public static ShowSelectedFood INSTANCE;
+
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
@@ -181,7 +183,11 @@ public class ShowSelectedFood extends ListActivity {
 						setExpand(0);
 					}
 				});
+
+		INSTANCE = this;
 	}
+
+
 
 	private void setExpand(int value) {
 		expandOrNotDBAdapater.open();

--- a/app/src/main/java/com/hippoandfriends/helpdiabetes/Show/Food/ShowUpdateFood.java
+++ b/app/src/main/java/com/hippoandfriends/helpdiabetes/Show/Food/ShowUpdateFood.java
@@ -35,6 +35,8 @@ public class ShowUpdateFood extends ListActivity {
 	private DBFood food;
 	private List<DBFoodUnit> listFoodUnit;
 
+	public static ShowUpdateFood INSTANCE;
+
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
@@ -75,6 +77,8 @@ public class ShowUpdateFood extends ListActivity {
 				onClickButtonAdd();
 			}
 		});
+
+		INSTANCE = this;
 	}
 
 	@Override

--- a/app/src/main/java/com/hippoandfriends/helpdiabetes/Show/Medicine/ShowMedicineTypes.java
+++ b/app/src/main/java/com/hippoandfriends/helpdiabetes/Show/Medicine/ShowMedicineTypes.java
@@ -29,6 +29,8 @@ public class ShowMedicineTypes extends ListActivity {
 	private List<DBMedicineType> listMedicineTypes;
 	private Button btAdd, btBack;
 
+	public static ShowMedicineTypes INSTANCE;
+
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
@@ -56,6 +58,7 @@ public class ShowMedicineTypes extends ListActivity {
 			}
 		});
 
+		INSTANCE = this;
 	}
 
 	// refresh the name of a object

--- a/app/src/main/java/com/hippoandfriends/helpdiabetes/Show/Tracking/ShowLoadingTrackingData.java
+++ b/app/src/main/java/com/hippoandfriends/helpdiabetes/Show/Tracking/ShowLoadingTrackingData.java
@@ -49,6 +49,8 @@ public class ShowLoadingTrackingData extends Activity {
 
 	public Date currentDateMinutOneWeek;
 
+	public static ShowLoadingTrackingData INSTANCE;
+
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
@@ -65,6 +67,8 @@ public class ShowLoadingTrackingData extends Activity {
 		listBloodGlucose = new ArrayList<DBBloodGlucoseEvent>();
 
 		context = this;
+
+		INSTANCE = this;
 	}
 
 	@Override


### PR DESCRIPTION
This addresses issue #6.  Instead of trying to obtain `Activity` instances from the views stored in each activity group's history list, I created static `INSTANCE` fields in each activity that are set in `onCreate`.  I tried clearing these fields in `onDestroy`, but then they are null when they are needed. This suggests that the app has always been leaking dead activity instances via the views in the history lists.

To be clear, this is a horrible hack, but I think it's the best that can be done without major refactoring.  The app heavily depends on classes that were deprecated at API level 13. The whole thing desperately needs to be rewritten using fragments.

This seems to work in an emulator.  Please test it on a real device if you can.